### PR TITLE
fix(desktop): Windows MSI creates shortcuts + in-app update

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -72,9 +72,11 @@ Récupérer le dernier build depuis les
 
 L'AppImage Linux embarque son runtime Java **et libVLC** : elle tourne sur
 n'importe quelle distribution sans rien installer (vérifié sur Ubuntu 22.04/24.04,
-Debian 12 et Arch). Elle se met aussi à jour depuis l'app. Sous **Windows et
-macOS**, VLC doit toujours être installé sur la machine, et l'installeur renvoie
-vers la page de release — un `.msi` exige les droits administrateur.
+Debian 12 et Arch) et se met à jour depuis l'app. Sous **Windows**, le `.msi`
+s'installe par utilisateur — sans droits administrateur — et ajoute des raccourcis
+au menu Démarrer et au bureau ; le bandeau intégré le met alors à jour en place.
+Sous **macOS**, le bandeau ouvre la page de release (le `.dmg` s'installe à la
+main). Windows et macOS nécessitent toujours **VLC** installé sur la machine.
 
 Au premier lancement, coller une [clé API TMDB](https://www.themoviedb.org/settings/api)
 gratuite dans **Réglages → API & Clés**. Les mises à jour suivantes se font depuis l'app.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ Grab the latest build from [Releases](https://github.com/JibayMcs/MooVie/release
 
 The Linux AppImage bundles its own Java runtime **and libVLC**, so it runs on any
 distribution with nothing to install (tested on Ubuntu 22.04/24.04, Debian 12 and
-Arch). It also updates itself from inside the app. On **Windows and macOS**, VLC
-must still be installed on the machine, and the installer sends you to the release
-page — an `.msi` needs admin rights.
+Arch), and updates itself from inside the app. On **Windows**, the `.msi` installs
+per user — no admin rights — and adds Start-menu and desktop shortcuts; the in-app
+banner then updates it in place. On **macOS**, the banner opens the release page
+(the `.dmg` is installed by hand). Windows and macOS still need **VLC** installed
+on the machine.
 
 On first launch, paste a free [TMDB API key](https://www.themoviedb.org/settings/api)
 under **Settings → API & Keys**. Later updates are handled from inside the app.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -195,7 +195,25 @@ compose.desktop {
             // (générés depuis docs/assets/sources/moo_vie_launcher_icon_master_1024x1024.png)
             // car la CI n'a pas d'outil de conversion ico/icns.
             linux { iconFile.set(project.file("icons/moovie.png")) }
-            windows { iconFile.set(project.file("icons/moovie.ico")) }
+            windows {
+                iconFile.set(project.file("icons/moovie.ico"))
+                // Sans raccourci ni groupe de menu, le MSI installait bien l'app
+                // (sous Program Files / LocalAppData) mais ne créait aucune
+                // entrée : ni menu Démarrer, ni bureau, ni icône visible — d'où
+                // l'impression que « l'installation ne marche pas ».
+                // menuGroup crée l'entrée menu Démarrer (menu = true en découle) ;
+                // shortcut ajoute le raccourci bureau.
+                menuGroup = "Moo-vie"
+                shortcut = true
+                // UUID figé : les MSI suivants remplacent l'installation en place
+                // au lieu de s'ajouter côte à côte. Doit rester constant d'une
+                // version à l'autre (comme upgradeUuid l'exige côté WiX).
+                upgradeUuid = "3bb04069-630b-44cc-ae44-8579cc165af4"
+                // Installation par utilisateur (%LOCALAPPDATA%) : pas d'élévation
+                // UAC, et surtout l'updater desktop peut réécrire les fichiers
+                // sans droits admin — cohérent avec la mise à jour in-app.
+                perUserInstall = true
+            }
             macOS { iconFile.set(project.file("icons/moovie.icns")) }
         }
     }

--- a/app/src/desktopMain/kotlin/fr/moovie/tv/desktop/DesktopUpdateViewModel.kt
+++ b/app/src/desktopMain/kotlin/fr/moovie/tv/desktop/DesktopUpdateViewModel.kt
@@ -27,11 +27,17 @@ import kotlin.system.exitProcess
  * Vérifie la dernière release GitHub au démarrage puis à l'intervalle choisi
  * dans les réglages.
  *
- * Lancée depuis une AppImage, l'app se met à jour elle-même : le paquet est un
- * fichier unique appartenant à l'utilisateur, donc remplaçable sans droits
- * particuliers. Partout ailleurs (`.msi` Windows, lancement depuis les sources)
- * on retombe sur l'ouverture de la page de release : ces paquets s'installent
- * hors de l'app et exigent une élévation de privilèges.
+ * Deux chemins de mise à jour en place :
+ *  - AppImage (Linux) : le paquet est un fichier unique appartenant à
+ *    l'utilisateur, on le télécharge, on se remplace et on relance.
+ *  - MSI (Windows) : depuis la 1.6.x le paquet s'installe par utilisateur
+ *    (`perUserInstall`), donc msiexec peut réinstaller par-dessus sans
+ *    élévation UAC ; l'`upgradeUuid` figé fait de la nouvelle version une mise
+ *    à niveau majeure qui remplace l'ancienne. On télécharge le `.msi`, on
+ *    lance msiexec depuis un script qui attend notre fermeture puis relance.
+ *
+ * Partout ailleurs (lancement depuis les sources, format sans self-update) on
+ * retombe sur l'ouverture de la page de release dans le navigateur.
  */
 class DesktopUpdateViewModel : ViewModel() {
 
@@ -47,6 +53,12 @@ class DesktopUpdateViewModel : ViewModel() {
 
     /** Asset .AppImage de la release courante, si elle en propose un. */
     private var appImageAssetUrl: String? = null
+
+    /** Asset .msi de la release courante, si elle en propose un. */
+    private var msiAssetUrl: String? = null
+
+    private val isWindows =
+        System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
 
     /**
      * Fichier AppImage en cours d'exécution. Le runtime AppImage exporte
@@ -83,6 +95,9 @@ class DesktopUpdateViewModel : ViewModel() {
         appImageAssetUrl = release.assets
             .firstOrNull { it.name.endsWith(".AppImage", ignoreCase = true) }
             ?.downloadUrl
+        msiAssetUrl = release.assets
+            .firstOrNull { it.name.endsWith(".msi", ignoreCase = true) }
+            ?.downloadUrl
         // apkUrl transporte ici l'URL de la page de release (repli navigateur).
         _state.value = UpdateState.Available(version, release.htmlUrl)
     }
@@ -94,20 +109,25 @@ class DesktopUpdateViewModel : ViewModel() {
     }
 
     /**
-     * Depuis une AppImage : télécharge la nouvelle version, remplace le fichier
-     * courant et relance. Sinon : ouvre la page de release.
+     * AppImage : télécharge la nouvelle version, remplace le fichier courant et
+     * relance. Windows/MSI : télécharge le `.msi` et le passe à msiexec. Sinon :
+     * ouvre la page de release dans le navigateur.
      */
     fun install() {
         val available = _state.value as? UpdateState.Available ?: return
-        val target = runningAppImage
-        val assetUrl = appImageAssetUrl
-        if (target == null || assetUrl.isNullOrBlank()) {
-            if (available.apkUrl.isNotBlank()) {
+        val appImage = runningAppImage
+        val appImageUrl = appImageAssetUrl
+        val msiUrl = msiAssetUrl
+        when {
+            appImage != null && !appImageUrl.isNullOrBlank() ->
+                viewModelScope.launch { replaceSelf(available.version, appImageUrl, appImage) }
+
+            isWindows && !msiUrl.isNullOrBlank() ->
+                viewModelScope.launch { installMsi(available.version, msiUrl) }
+
+            available.apkUrl.isNotBlank() ->
                 runCatching { Desktop.getDesktop().browse(URI(available.apkUrl)) }
-            }
-            return
         }
-        viewModelScope.launch { replaceSelf(available.version, assetUrl, target) }
     }
 
     private suspend fun replaceSelf(version: String, url: String, target: File) {
@@ -144,6 +164,76 @@ class DesktopUpdateViewModel : ViewModel() {
         }
         relaunch(target)
         exitProcess(0)
+    }
+
+    /**
+     * Windows : télécharge le `.msi` de la release et le confie à msiexec via un
+     * script qui attend la fermeture de cette instance avant de réécrire les
+     * fichiers, puis relance l'app.
+     */
+    private suspend fun installMsi(version: String, url: String) {
+        _state.value = UpdateState.Downloading(version, 0f)
+        // %TEMP% et non le dossier d'install : les fichiers de l'app sont sur le
+        // point d'être remplacés par msiexec, on n'écrit rien dedans.
+        val staged = File(System.getProperty("java.io.tmpdir"), "Moo-vie-$version.msi")
+        val downloaded = repo.downloadApk(url, staged) { progress ->
+            _state.value = UpdateState.Downloading(version, progress)
+        }
+        if (!downloaded || !isMsi(staged)) {
+            staged.delete()
+            _state.value = UpdateState.Error(getString(Res.string.update_error))
+            return
+        }
+        val launched = withContext(Dispatchers.IO) {
+            runCatching { launchMsiInstaller(staged) }.isSuccess
+        }
+        if (!launched) {
+            staged.delete()
+            _state.value = UpdateState.Error(getString(Res.string.update_error))
+            return
+        }
+        // On sort tout de suite : msiexec, détaché, ne peut pas mettre à niveau
+        // tant que l'exécutable courant tient ses fichiers ouverts.
+        exitProcess(0)
+    }
+
+    /**
+     * Écrit et démarre, détaché, un script qui : attend quelques secondes que ce
+     * processus meure, lance msiexec (`/qb` : barre de progression, aucune
+     * question ; pas d'UAC car l'install est par utilisateur), relance l'app
+     * fraîchement installée, puis se supprime.
+     *
+     * Le script est nécessaire parce qu'on ne peut ni attendre msiexec (il doit
+     * survivre à notre mort) ni relancer l'app depuis un processus qu'on tue.
+     */
+    private fun launchMsiInstaller(msi: File) {
+        // Lanceur natif jpackage (Moo-vie.exe) : même chemin après une mise à
+        // niveau majeure au même INSTALLDIR, donc relançable tel quel. Absent →
+        // on renonce à la relance, l'utilisateur rouvre via le raccourci.
+        val exe = ProcessHandle.current().info().command().orElse(null)
+        val log = File(System.getProperty("java.io.tmpdir"), "Moo-vie-update.log")
+        val script = File.createTempFile("moovie-update", ".cmd").apply {
+            writeText(
+                buildString {
+                    appendLine("@echo off")
+                    // ping plutôt que timeout : ce dernier exige un vrai console
+                    // input, absent d'un process démarré détaché.
+                    appendLine("ping 127.0.0.1 -n 3 >nul")
+                    appendLine(
+                        "msiexec /i \"${msi.absolutePath}\" /qb /norestart " +
+                            "/l*v \"${log.absolutePath}\"",
+                    )
+                    if (exe != null) appendLine("start \"\" \"$exe\"")
+                    // %~f0 : le script se supprime lui-même en dernier.
+                    appendLine("del \"%~f0\"")
+                },
+            )
+        }
+        // start "" /min : la fenêtre du script est détachée de ce process et
+        // survivra à exitProcess ; minimisée pour ne pas surgir au premier plan.
+        ProcessBuilder("cmd", "/c", "start", "", "/min", script.absolutePath)
+            .apply { scrubLauncherEnv(environment()) }
+            .start()
     }
 
     /**
@@ -219,6 +309,27 @@ class DesktopUpdateViewModel : ViewModel() {
                     header[8] == 'A'.code.toByte() &&
                     header[9] == 'I'.code.toByte() &&
                     header[10] == 0x02.toByte()
+            }
+        }.getOrDefault(false)
+    }
+
+    /**
+     * Vérifie que le fichier est bien un MSI : un `.msi` est un fichier composé
+     * OLE2, reconnaissable à sa signature `D0 CF 11 E0 A1 B1 1A E1`. Sans ce
+     * contrôle, une page d'erreur HTML servie à la place du binaire serait
+     * passée à msiexec, qui échouerait sans qu'on sache pourquoi.
+     */
+    private suspend fun isMsi(file: File): Boolean = withContext(Dispatchers.IO) {
+        runCatching {
+            file.inputStream().use { input ->
+                val header = ByteArray(8)
+                if (input.read(header) < header.size) return@use false
+                header.contentEquals(
+                    byteArrayOf(
+                        0xD0.toByte(), 0xCF.toByte(), 0x11, 0xE0.toByte(),
+                        0xA1.toByte(), 0xB1.toByte(), 0x1A, 0xE1.toByte(),
+                    ),
+                )
             }
         }.getOrDefault(false)
     }


### PR DESCRIPTION
## Problem

On Windows, the released `.msi` installed the app but left it **impossible to
find**: no shortcut was created (neither Start menu nor desktop), and no icon
showed during installation. The `windows { }` block in `build.gradle.kts` only
configured the icon → the MSI's `Shortcut` table was empty.

On top of that, the "in-app update" didn't actually work on Windows: the
"Install" banner merely opened the release page in the browser, leaving the user
to re-download and reinstall by hand.

## Changes

**1. Windows MSI (`app/build.gradle.kts`)**
- `menuGroup = "Moo-vie"` → Start-menu entry
- `shortcut = true` → desktop shortcut
- `perUserInstall = true` → installs under `%LOCALAPPDATA%` **with no UAC elevation**
- fixed `upgradeUuid` → subsequent MSIs replace the install in place
  (WiX major upgrade) instead of installing side by side

**2. Windows in-app update (`DesktopUpdateViewModel.kt`)**
`install()` becomes platform-aware. On Windows it downloads the release's `.msi`
asset, checks its OLE2 header, then runs `msiexec /qb` from a detached script that
waits for the current instance to close, reinstalls (no admin thanks to
`perUserInstall`) and relaunches the app. The browser fallback now only remains
where there is no self-update (macOS, running from source).

**3. Docs (`README.md` / `README.fr.md`)**
Install section corrected: Windows now installs without admin rights, creates its
shortcuts and updates in place; only macOS keeps the redirect to the release page.

## Verification (end-to-end, portable WiX 3.14)

- Built MSI → the `Shortcut` table contains both **desktop + Start menu\Moo-vie**,
  `UpgradeCode` = the fixed UUID, icons embedded.
- MSI installed from a **non-elevated shell** → `msiexec` returns `0`, **no UAC**
  (proving `perUserInstall` works, and that the updater approach is viable).
- Desktop + Start-menu shortcuts created, icon present, **app launched successfully**.
- Clean uninstall (`msiexec /x`, exit 0, folder and shortcuts removed).