### PR TITLE
fix(desktop): AppImage declares StartupWMClass so the dock shows the …

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,9 +163,14 @@ compose.resources {
     packageOfResClass = "fr.moovie.tv.resources"
 }
 
+// Classe principale du desktop. Extraite en constante parce que l'AppImage en
+// dérive aussi son StartupWMClass : AWT nomme la WM_CLASS X11 d'après elle, en
+// remplaçant les points par des tirets.
+val desktopMainClass = "fr.moovie.tv.desktop.MainKt"
+
 compose.desktop {
     application {
-        mainClass = "fr.moovie.tv.desktop.MainKt"
+        mainClass = desktopMainClass
         // Version lue au runtime par l'updater desktop (bannière de mise à jour).
         jvmArgs += "-Dmoovie.version=$appVersion"
 
@@ -383,6 +388,7 @@ val packageAppImage by tasks.registering {
             Icon=moovie
             Categories=AudioVideo;Video;Player;
             Terminal=false
+            StartupWMClass=${desktopMainClass.replace('.', '-')}
             """.trimIndent() + "\n",
         )
         // $APPDIR n'est pas fiable selon le mode de montage : on résout le


### PR DESCRIPTION
…app icon

The generated moovie.desktop had no StartupWMClass, so desktop shells could not match the running window to the desktop entry and fell back to the generic placeholder icon in the dock and the alt-tab switcher.

AWT derives the X11 WM_CLASS from the main class, replacing dots with hyphens: fr.moovie.tv.desktop.MainKt becomes fr-moovie-tv-desktop-MainKt. Verified with xprop against a running v1.6.1 AppImage on Ubuntu 24.04.

The main class is extracted into a val and the WM_CLASS derived from it, so renaming the entry point keeps the desktop entry in sync instead of silently breaking the icon again.