### PR TITLE
Details page: make the hero fit a television

### DIFF
--- a/app/src/commonMain/kotlin/fr/moovie/tv/ui/details/DetailsHero.kt
+++ b/app/src/commonMain/kotlin/fr/moovie/tv/ui/details/DetailsHero.kt
@@ -36,12 +36,37 @@ import fr.moovie.tv.resources.info_creator
 import fr.moovie.tv.resources.info_director
 import fr.moovie.tv.resources.media_movie
 import fr.moovie.tv.resources.media_series
+import fr.moovie.tv.ui.adaptive.HeightClass
+import fr.moovie.tv.ui.adaptive.LocalHeightClass
 import fr.moovie.tv.ui.components.MoovieAsyncImage
 import fr.moovie.tv.ui.theme.MoovieShape
 import org.jetbrains.compose.resources.stringResource
 
 /** Le gris des lignes secondaires du hero — celui du reste de la fiche. */
 private val HERO_DIM = Color(0xFF9A9A9A)
+
+/**
+ * La hauteur que le voile couvre, mesurée depuis le bas du cadre.
+ *
+ * C'est la place que prend le bloc de texte — titre, ligne de méta, bouton
+ * principal, rangée d'actions — plus de quoi respirer au-dessus. Deux valeurs
+ * parce que le bloc lui-même en a deux : resserré sur un cadre court, ample
+ * ailleurs (voir [CADRE_COURT]). Un voile calé sur la version ample couvrirait
+ * neuf dixièmes d'un cadre de téléviseur, soit très exactement le défaut qu'il
+ * est censé corriger.
+ */
+private val HAUTEUR_VOILE = 330.dp
+private val HAUTEUR_VOILE_COURT = 210.dp
+
+/**
+ * Largeur au-delà de laquelle un titre cesse de se lire d'un trait.
+ *
+ * Le titre occupe toute la largeur du cadre pour ne jamais être coupé (voir
+ * plus bas), mais « toute la largeur » d'une fenêtre de bureau fait mille sept
+ * cents points : l'œil y perd la fin de la première ligne avant d'avoir trouvé
+ * le début de la seconde.
+ */
+private val LARGEUR_MAX_TITRE = 1100.dp
 
 /**
  * L'en-tête d'une fiche, sur les écrans qu'on regarde de loin ou en grand.
@@ -140,18 +165,36 @@ internal fun DetailsHero(
         // ciel de jour derrière lui suffit à le rendre illisible. Le second est
         // plus faible que le premier — il corrige, il ne repeint pas.
         //
-        // **Les paliers suivent le texte, pas une proportion fixe.** Le cadre
-        // occupe désormais toute la hauteur visible : les mêmes arrêts, calés
-        // pour un hero de 620 dp, noircissaient la moitié d'une image de
-        // 1 400 dp — c'est-à-dire l'image elle-même, qui est tout le sujet.
-        // Le bloc de texte tient dans le dernier tiers ; le dégradé n'assombrit
-        // donc que là, et laisse le reste tel qu'il est.
+        // **Le voile s'ancre sur le bas, en points, pas en fraction.**
+        //
+        // Des paliers exprimés en pourcentage supposent que le bloc de texte
+        // occupe toujours la même part du cadre. Il n'en occupe pas du tout la
+        // même : il fait à peu près la même hauteur physique partout — un
+        // titre, une ligne de méta, un bouton, une rangée d'icônes — alors que
+        // le cadre, lui, suit l'écran. Sur une fenêtre de bureau haute de
+        // 1 045 dp, le hero en fait 941 et le texte un quart ; sur un
+        // téléviseur 1080p, qui ne fait que 540 dp de haut, le hero tombe à 436
+        // et le même texte en occupe plus de la moitié.
+        //
+        // Les mêmes fractions y noircissaient donc la moitié de l'image, et le
+        // cadre se lisait comme une bande d'image posée sur un bloc noir —
+        // exactement ce qu'on nous a remonté d'un salon. Ancré en points, le
+        // voile couvre le texte et rien de plus, quelle que soit la hauteur.
+        val voile = if (LocalHeightClass.current != HeightClass.EXPANDED) {
+            HAUTEUR_VOILE_COURT
+        } else {
+            HAUTEUR_VOILE
+        }
+        val debutVoile = ((hauteur - voile) / hauteur).coerceIn(0.05f, 0.75f)
         Box(
             modifier = Modifier.fillMaxSize().background(
                 Brush.verticalGradient(
                     0f to Color(0x000A0A0A),
-                    0.38f to Color(0x1A0A0A0A),
-                    0.62f to Color(0x990A0A0A),
+                    debutVoile to Color(0x000A0A0A),
+                    // Le gros de l'assombrissement se fait sur la seconde
+                    // moitié du voile : au-dessus, le texte n'a pas encore
+                    // commencé et l'image n'a aucune raison de payer pour lui.
+                    (debutVoile + (1f - debutVoile) * 0.45f) to Color(0x800A0A0A),
                     1f to Color(0xFF0A0A0A),
                 ),
             ),
@@ -165,11 +208,48 @@ internal fun DetailsHero(
             ),
         )
 
-        Row(
+        // **Court quand l'appareil est court, pas quand le cadre l'est.**
+        //
+        // C'est la hauteur offerte par l'appareil qui décide de la typographie,
+        // et le projet la nomme déjà : un téléviseur 1080p fait 540 dp de haut
+        // ([HeightClass.MEDIUM]), une fenêtre de bureau plus de 900
+        // ([HeightClass.EXPANDED]). Un seuil maison sur la hauteur du cadre
+        // aurait dit à peu près la même chose, en inventant un second
+        // vocabulaire pour la même question.
+        val court = LocalHeightClass.current != HeightClass.EXPANDED
+        Column(
             modifier = Modifier
                 .align(Alignment.BottomStart)
                 .fillMaxWidth()
-                .padding(horizontal = marge, vertical = 28.dp),
+                .padding(horizontal = marge, vertical = if (court) 18.dp else 28.dp),
+            verticalArrangement = Arrangement.spacedBy(if (court) 8.dp else 12.dp),
+        ) {
+        // **Le titre occupe toute la largeur, au-dessus des deux colonnes.**
+        //
+        // Enfermé dans la colonne de gauche — un tiers du cadre —, il était
+        // coupé dès qu'il dépassait trois mots : « The Lord of the Rings: The
+        // Fellowship of the Ring » n'y tenait pas, et l'ellipse tombait au
+        // milieu du titre qu'on venait chercher. C'est le seul élément du hero
+        // dont la longueur ne se négocie pas : on lui donne la largeur.
+        Text(
+            titre,
+            // `displayMedium` fait quarante-cinq points : sur un téléviseur,
+            // un titre de deux mots y passe à la ligne et coûte cent vingt
+            // points de cadre à lui seul. Un cran en dessous tient sur une
+            // ligne et rend cette hauteur à l'image, sans qu'on lise moins bien
+            // de trois mètres — la taille reste très au-dessus du reste.
+            style = if (court) {
+                MaterialTheme.typography.headlineLarge
+            } else {
+                MaterialTheme.typography.displayMedium
+            },
+            color = Color.White,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.widthIn(max = LARGEUR_MAX_TITRE),
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(40.dp),
             verticalAlignment = Alignment.Bottom,
         ) {
@@ -211,15 +291,8 @@ internal fun DetailsHero(
             // ligne devient trop longue pour qu'on retrouve la suivante.
             Column(
                 modifier = Modifier.weight(0.34f),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(if (court) 8.dp else 12.dp),
             ) {
-                Text(
-                    titre,
-                    style = MaterialTheme.typography.displayMedium,
-                    color = Color.White,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
                 val ligne = meta.filter { it.isNotBlank() }
                 if (ligne.isNotEmpty()) {
                     Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
@@ -247,7 +320,7 @@ internal fun DetailsHero(
                         synopsis,
                         style = MaterialTheme.typography.bodyMedium,
                         color = Color(0xFFDDDDDD),
-                        maxLines = 4,
+                        maxLines = if (court) 3 else 4,
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
@@ -265,6 +338,7 @@ internal fun DetailsHero(
             if (aside != null) {
                 Box(modifier = Modifier.align(Alignment.Bottom)) { aside() }
             }
+        }
         }
 
         // Dernier de la pile : elles se posent sur la vidéo comme sur les

--- a/app/src/commonMain/kotlin/fr/moovie/tv/ui/details/DetailsScreen.kt
+++ b/app/src/commonMain/kotlin/fr/moovie/tv/ui/details/DetailsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -80,6 +81,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import fr.moovie.tv.ui.theme.MoovieShape
 import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -217,6 +219,15 @@ private const val SCROLL_SETTLE_MS = 120L
  * la page se calerait alors seize points à côté, ce qui se voit.
  */
 private val ESPACEMENT_PAGE = 16.dp
+
+/**
+ * De combien on grossit la bande-annonce pour sortir ses barres du cadre.
+ *
+ * 2,39 ÷ 2,07 : le rapport entre le format d'un film et celui du hero. En
+ * dessous, les barres d'un 2,39:1 restent visibles ; au-dessus, on ampute pour
+ * rien les bandes-annonces qui n'en ont pas.
+ */
+private const val ZOOM_APERCU = 1.16f
 
 private const val HERO_PREVIEW_DELAY_MS = 3_000L
 
@@ -856,7 +867,7 @@ fun DetailsScreenContent(
         // Le plancher tient le cas d'une fenêtre écrasée en hauteur, où le titre
         // et les boutons ne tiendraient plus — on préfère alors déborder et
         // laisser défiler.
-        val hauteurHero = (maxHeight - HAUTEUR_ONGLETS - AMORCE_SOUS_ONGLETS)
+        val hauteurHero = (maxHeight - hauteurOnglets() - amorceSousOnglets())
             .coerceAtLeast(300.dp)
         // **La marge du hero n'est pas celle de la page.**
         //
@@ -925,12 +936,33 @@ fun DetailsScreenContent(
                     Modifier.fillMaxSize()
                 },
             ) {
-                trailerPreview(
-                    ready.stream,
-                    volume,
-                    { trailerController = it },
-                    Modifier.fillMaxSize(),
-                )
+                // **Un peu plus que remplir : mordre.**
+                //
+                // Les deux lecteurs recadrent déjà pour couvrir le cadre, et ça
+                // ne suffit pas. Une bande-annonce de cinéma est un 2,39:1
+                // **encodé dans un 16:9** : les barres noires sont dans les
+                // images, pas autour de la vidéo, et aucun mode de
+                // redimensionnement ne les distingue du film. Couvrir un cadre
+                // de 2,07:1 avec ce 16:9 en retire la moitié ; le reste
+                // s'affiche en haut et en bas du hero, en bandes franches — ce
+                // qu'on nous a remonté d'un salon comme des « séparations ».
+                //
+                // Ce grossissement les fait sortir du cadre. Il coûte 15 % de
+                // débord à une bande-annonce réellement en 16:9, ce qui est le
+                // bon échange : c'est un décor, pas un plan qu'on cadre.
+                Box(
+                    modifier = Modifier.fillMaxSize().clipToBounds(),
+                ) {
+                    trailerPreview(
+                        ready.stream,
+                        volume,
+                        { trailerController = it },
+                        Modifier.fillMaxSize().graphicsLayer {
+                            scaleX = ZOOM_APERCU
+                            scaleY = ZOOM_APERCU
+                        },
+                    )
+                }
             }
         }
 
@@ -981,15 +1013,20 @@ fun DetailsScreenContent(
         // haut : on garde le moyen de changer d'avis.
         //
         // La cible se calcule, elle ne se mesure pas : le hero est le premier
-        // élément de la colonne et la barre le suit, séparés du seul espacement
-        // de la colonne. Un `onGloballyPositioned` aurait donné le même nombre
-        // au prix d'un état de plus et d'une image de retard.
+        // élément de la colonne et la barre lui est collée. Un
+        // `onGloballyPositioned` aurait donné le même nombre au prix d'un état
+        // de plus et d'une image de retard.
         val densite = LocalDensity.current
-        val hautDesOnglets = with(densite) { (hauteurHero + ESPACEMENT_PAGE).roundToPx() }
+        val hautDesOnglets = with(densite) { hauteurHero.roundToPx() }
         // Défini une fois pour les deux fiches : c'est la même barre, au même
         // endroit, et la dupliquer aurait fini par la faire diverger.
         val barreOnglets: @Composable () -> Unit = {
-            BandeauOnglets {
+            // Remontée de l'espacement de la page : la barre doit **toucher**
+            // le bas de l'image, comme la maquette. Les seize points de noir
+            // que la colonne glissait entre les deux ajoutaient une troisième
+            // bande sombre à un bas d'écran qui en comptait déjà deux — et
+            // c'est cet empilement qu'on lit comme des blocs séparés.
+            BandeauOnglets(modifier = Modifier.offset(y = -ESPACEMENT_PAGE)) {
                 DetailsTabs(
                     onglets = onglets,
                     actif = ongletActif,

--- a/app/src/commonMain/kotlin/fr/moovie/tv/ui/details/DetailsTabs.kt
+++ b/app/src/commonMain/kotlin/fr/moovie/tv/ui/details/DetailsTabs.kt
@@ -21,6 +21,8 @@ import fr.moovie.tv.resources.details_tab_episodes
 import fr.moovie.tv.resources.details_tab_info
 import fr.moovie.tv.resources.details_tab_similar
 import fr.moovie.tv.resources.details_tab_trailers
+import fr.moovie.tv.ui.adaptive.HeightClass
+import fr.moovie.tv.ui.adaptive.LocalHeightClass
 import fr.moovie.tv.ui.components.MoovieButton
 import fr.moovie.tv.ui.theme.MOOVIE_ACCENT
 import org.jetbrains.compose.resources.StringResource
@@ -125,24 +127,28 @@ internal enum class DetailsTab(val libelle: StringResource) {
 }
 
 /**
- * La hauteur que la barre prend sous le hero.
+ * La hauteur que la barre prend sous le hero, et l'amorce laissée dessous.
  *
  * Le hero s'en sert pour se dimensionner : la maquette montre l'image jusqu'au
- * bas de l'écran **et** la barre posée dessous, visible sans défiler. C'est
- * elle qui dit qu'il y a une suite — sans quoi la page paraît finie, et l'on ne
- * saurait pas que les épisodes existent.
- */
-internal val HAUTEUR_ONGLETS: Dp = 64.dp
-
-/**
- * L'amorce laissée **sous** la barre.
+ * bas de l'écran **et** la barre posée dessous, visible sans défiler. L'amorce,
+ * elle, découvre le haut de ce que la barre ouvre — une affiche, une ligne
+ * d'épisode — et c'est elle, pas la barre, qui donne envie de défiler.
  *
- * Réserver la seule hauteur de la barre la posait pile sur le bord de l'écran :
- * on la voyait, mais rien ne disait qu'elle avait un contenu. Ces quelques
- * points découvrent le haut de ce qu'elle ouvre — une affiche, une ligne
- * d'épisode — et c'est cette amorce, pas la barre, qui donne envie de défiler.
+ * **Deux jeux de valeurs, parce que ce sont deux budgets.** Ensemble elles
+ * prennent 104 dp au cadre. Sur une fenêtre de bureau haute de 1 045 dp, c'est
+ * un dixième et personne ne le remarque ; sur un téléviseur 1080p, qui n'en
+ * fait que 540, c'est un cinquième de l'écran — un cinquième de noir sous
+ * l'image, qui la fait lire comme un bandeau posé sur un bloc. La barre reste
+ * confortable à viser à la télécommande : le bouton qu'elle porte fait sa
+ * propre hauteur, on ne réduit que l'air autour.
  */
-internal val AMORCE_SOUS_ONGLETS: Dp = 40.dp
+@Composable
+internal fun hauteurOnglets(): Dp =
+    if (LocalHeightClass.current == HeightClass.EXPANDED) 64.dp else 52.dp
+
+@Composable
+internal fun amorceSousOnglets(): Dp =
+    if (LocalHeightClass.current == HeightClass.EXPANDED) 40.dp else 24.dp
 
 /** Bandeau plein pour la barre, comme la maquette : elle sort de l'image. */
 @Composable
@@ -150,7 +156,7 @@ internal fun BandeauOnglets(modifier: Modifier = Modifier, contenu: @Composable 
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(HAUTEUR_ONGLETS)
+            .height(hauteurOnglets())
             .background(Color(0xFF0A0A0A))
             .padding(vertical = 6.dp),
         contentAlignment = Alignment.CenterStart,


### PR DESCRIPTION
Follow-up to #9 : the artwork read as a band squeezed between black blocks, and titles were cut off.

The cause is one number. A 1080p television is **540 dp** tall; the window this page was designed in is **1045**. The text block is the same physical size on both — a title, a meta line, a button, a row of icons — so it goes from a quarter of the frame to more than half. Everything expressed as a *fraction* of the frame, or in fixed dp, was tuned for the wrong screen.

**What changed**

- **The veil is anchored to the bottom in dp**, sized on the text block it exists to cover, instead of at fractions of the height. The old stops blackened half the image on a short frame.
- **Typography follows `LocalHeightClass`** — the vocabulary the project already had — rather than a threshold invented for this page. Below `EXPANDED` the title drops one step and fits on a line instead of taking two.
- **The title spans the full width**, above both columns. Boxed in the left third it ellipsised past three words: *The Lord of the Rings: The Rings of Power* never fit.
- **The tab bar and its peek follow the height class too.** At 104 dp together they are a tenth of a desktop window and a fifth of a television.
- **The tab bar butts against the image.** The sixteen points the page slid between them added a third dark band to a screen bottom that already had two, and that stack is what reads as separated blocks.
- **The trailer is scaled 1.16.** A cinema trailer is 2.39:1 encoded inside a 16:9 — the bars are *in* the frames, and no resize mode tells them from the film. Covering a 2.07:1 hero removed half of them; the rest showed as hard bands above the artwork. 1.16 is 2.39 ÷ 2.07.

**Measured** on the Android TV emulator (`tv36`), same pixel column, before → after:

| | before | after |
|---|---|---|
| Image luminance at mid-height | `0x4B` | `0x60` |
| Black band above the trailer | 110 px | 0 |
| Long title | ellipsised | one line |

Desktop re-checked after the title move: no regression.